### PR TITLE
Add Google Search Engine to site

### DIFF
--- a/_layouts/blog/index.html
+++ b/_layouts/blog/index.html
@@ -3,6 +3,19 @@
 <main{% if page.slug %} class="{{ page.slug }}"{% elsif page.title %} class="{{ page.title | slugify }}"{% endif %} role="main">
 
   <div class="single-column blog-index">
+		<section class="search">
+			<h2>Explore the blog</h2>
+			<p>I've been writing about web development since 2012. To date, there are
+      <strong>{{ site.posts | size }} posts</strong> ranging from Elixir and
+      Ruby on Rails to Linux server configuration. If you're interested in a
+      particular topic, check out the <a href="{{ '/tags' | prepend:
+      site.baseurl }}">tags section</a> or search for a topic below:</p>
+			<div class="search__container">
+				<input class="search__input" id="search-text" name="search" placeholder="Search the blog" type="text">
+				<input class="search__button" id="search-button" name="google-search-name" type="submit" value="Search">
+			</div>
+			<gcse:searchresults-only gname="searchOnlyCSE" linktarget="_parent"></gcse:searchresults-only>
+		</section>
     <section class="summary">
       <ul class="summary__list summary-list">
         {% for post in paginator.posts %}

--- a/_sass/modules/_gsc.scss
+++ b/_sass/modules/_gsc.scss
@@ -1,0 +1,29 @@
+/// All important styles added to override Google's injected styles
+
+.gsc-control-cse {
+  height: 0 !important;
+  width: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.gsc-results-wrapper-overlay {
+  &.gsc-results-wrapper-visible {
+    background: $body-bg;
+    color: $text-color;
+    font-family: $font-family-sans-serif;
+    font-size: $font-size-base * .875;
+    line-height: 1.5 !important;
+  }
+
+  .gs-title {
+    font-weight: bold;
+    height: initial !important;
+    font-size: 1.15rem !important;
+    text-decoration: none !important;
+  }
+
+  .gs-image {
+    margin: 0 auto;
+  }
+}

--- a/_sass/modules/_modules.scss
+++ b/_sass/modules/_modules.scss
@@ -15,3 +15,5 @@
 @import 'pagination';
 @import 'navigation-group';
 @import 'category-list';
+@import 'search';
+@import 'gsc';

--- a/_sass/modules/_search.scss
+++ b/_sass/modules/_search.scss
@@ -1,0 +1,47 @@
+.search {
+  @extend %border-radius;
+  @extend %box-shadow;
+
+  background: #fff; 
+  display: none;
+  margin-bottom: 5rem;
+  padding: 1.25rem 1.25rem 3rem 1.25rem;
+
+  @media screen and (min-width: 870px) {
+    display: block;
+  }
+
+  h2 {
+    color: $header-color;
+    line-height: 1.25rem;
+    margin-bottom: 0.25rem;
+  }
+
+  p {
+    padding-bottom: 1rem;
+  }
+
+  &__container {
+    width: 100%;
+    display: flex;
+  }
+
+  &__input {
+    @extend %border-radius;
+
+    border: 1px solid lighten($fuscous-grey, 50%);
+    flex: 4;
+    padding: 1px 5px;
+  }
+
+  &__button {
+    @extend %border-radius;
+
+    background: $link-color;
+    border: 0;
+    color: #fff;
+    flex: 1;
+    margin: 0 0 0 1rem;
+    padding: 2px 8px;
+  }
+}

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,3 +1,4 @@
 ---
 layout: blog/index
+custom_js: [search.js]
 ---

--- a/js/search.js
+++ b/js/search.js
@@ -1,0 +1,33 @@
+
+$(function() {
+  window.__gcse = {
+    callback: googleCSELoaded
+  };
+
+  function googleCSELoaded() {
+
+    $("#search-button").on('click', function() {
+      var searchText = $("#search-text").val();
+      var element    = google.search.cse.element.getElement("searchOnlyCSE");
+      element.execute(searchText);
+    });
+
+    $("#search-text").on('keyup', function(e) {
+      if (e.keyCode == 13) {
+        var searchText = $("#search-text").val();
+        var element    = google.search.cse.element.getElement("searchOnlyCSE");
+        element.execute(searchText);
+      }
+    })
+  }
+
+  (function() {
+    var cx = '005588353414550359789:csnxl5bz9jw';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = '//cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+});


### PR DESCRIPTION
Add Google's custom search engine to the site, and style results to resemble the
rest of the site. A couple of links helped with the current functionality of
having the search results show up via a popup on the same page:

http://stackoverflow.com/questions/10021761/loading-google-custom-search-results-without-page-refresh

Closes #7.