### PR TITLE
Load Disqus on button click

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,8 @@ defaults:
     values:
       layout: "default"
       tags: []
-      author: Daniel Strunk
+      author: "Daniel Strunk"
+      custom_js: [disqus.js]
 
 # gems
 gems:

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -1,22 +1,2 @@
+<button id="show-comments" class="button--centered">Show comments</button>
 <div id="disqus_thread"></div>
-<script>
-    /**
-     *  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
-     *  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables
-     */
-    /*
-    var disqus_config = function () {
-        this.page.url = PAGE_URL;  // Replace PAGE_URL with your page's canonical URL variable
-        this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
-    };
-    */
-    (function() {  // DON'T EDIT BELOW THIS LINE
-        var d = document, s = d.createElement('script');
-        
-        s.src = '//danielstrunk.disqus.com/embed.js';
-        
-        s.setAttribute('data-timestamp', +new Date());
-        (d.head || d.body).appendChild(s);
-    })();
-</script>
-<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>

--- a/_layouts/blog/index.html
+++ b/_layouts/blog/index.html
@@ -3,6 +3,8 @@
 <main{% if page.slug %} class="{{ page.slug }}"{% elsif page.title %} class="{{ page.title | slugify }}"{% endif %} role="main">
 
   <div class="single-column blog-index">
+
+    {% if paginator.page == 1 %}
 		<section class="search">
 			<h2>Explore the blog</h2>
 			<p>I've been writing about web development since 2012. To date, there are
@@ -17,6 +19,8 @@
 			<gcse:searchresults-only gname="searchOnlyCSE" linktarget="_parent"
       resultsUrl="{{ '/blog' | prepend: site.baseurl }}" queryParameterName="q"></gcse:searchresults-only>
 		</section>
+    {% endif %}
+
     <section class="summary">
       <ul class="summary__list summary-list">
         {% for post in paginator.posts %}

--- a/_sass/modules/_buttons.scss
+++ b/_sass/modules/_buttons.scss
@@ -4,7 +4,7 @@ button,
   border: 0;
   border-radius: 2px;
   color: #fff;
-  display: inline-block;
+  display: block;
   margin: 3rem 0;
   padding: 1rem 1.5rem;
   text-align: center;
@@ -13,5 +13,9 @@ button,
   &:hover {
     border: none;
     box-shadow: 0 4px 8px rgba($text-color, 0.2);
+  }
+
+  &--centered {
+    margin: 3rem auto;
   }
 }

--- a/js/disqus.js
+++ b/js/disqus.js
@@ -1,0 +1,14 @@
+$(function() {
+  $("#show-comments").on("click", function() {
+    var disqusShortname = "danielstrunk";
+
+    $.ajax({
+      type: "GET",
+      url: "//" + disqusShortname + ".disqus.com/embed.js",
+      dataType: "script",
+      cache: true
+    });
+
+    $(this).fadeOut();
+  });
+});


### PR DESCRIPTION
Only load Disqus on button click, which _drastically_ decreases load
times for JavaScript. Like ... seriously.

**One thing to note:** the `disqus.js` JavaScript has been added to the
post defaults, which means if any post overrides this default, the
`disqus.js` file will need to be added alongside any other custom JS
files.

Closes #6.